### PR TITLE
Fix breaking bug in `angvec2r`.

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -752,7 +752,7 @@ def angvec2r(theta: float, v: ArrayLike3, unit="rad", tol: float = 20) -> SO3Arr
     if np.linalg.norm(v) < tol * _eps:
         return np.eye(3)
 
-    θ = getunit(theta, unit)
+    θ = getunit(theta, unit, vector=False)
 
     # Rodrigue's equation
 


### PR DESCRIPTION
Changes to `getvector` behaviour mean that a scalar argument becomes a 1D vector which breaks the Rodrigue's equation. Fix is to pass `vector=False` to `getvector`.

8 unit tests are failing because of this.  GH CI is reporting this.  Should have been picked up earlier in the workflow.