### PR TITLE
Only explicitly support 3.10 and up.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,12 @@ authors = [
 ]
 description = "Provides spatial maths capability for Python."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     # Indicate who your project is intended for
     "Intended Audience :: Developers",
     # Specify the Python versions you support here.
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Per discussion with @jbarry-bdai and @petercorke, we're going to remove explicit support for python version less than 3.10 because the type hint system is just better from that version onwards.

This also seems to fix the unit tests consistently failing issue.