### PR TITLE
Fix typo on README.md due to change of location of the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 A Python implementation of the <a href="https://github.com/petercorke/spatial-math">Spatial Math Toolbox for MATLAB<sup>&reg;</sup></a>
 <ul>
 <li><a href="https://github.com/rai-opensource/spatialmath-python">GitHub repository </a></li>
-<li><a href="https://https://spatialmath-python.rai-inst.com">Documentation</a></li>
+<li><a href="https://spatialmath-python.rai-inst.com">Documentation</a></li>
 <li><a href=https://github.com/rai-opensource/spatialmath-python/discussions/categories/changes>Recent changes</a>
 <li><a href="https://github.com/rai-opensource/spatialmath-python/wiki">Wiki (examples and details)</a></li>
 <li><a href="installation#">Installation</a></li>

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Similarly when we assign an element or slice of the symbolic matrix to a numeric
 
 On April 28, 2026 this repository moved to the **RAI-Opensource** GitHub organization.  If you are still pulling from the previous bdaiinstitute GitHub organization, please update your git remote:
    ```bash
-   git remote set-url origin https://github.com/RAI-Opensource/spot_ros2
+   git remote set-url origin https://github.com/RAI-Opensource/spatialmath-python.git
    ```
 
 Also update any links of `https://bdaiinstitute.github.io/spatialmath-python` to  <https://spatialmath-python.rai-inst.com/>.


### PR DESCRIPTION
Hi all

This PR fixes a small typo in the migration notice: the repository URL pointed to `spot_ros2` instead of `spatialmath-python`.
