### PR TITLE
fix(base): export tr2pos2, pos2tr2, tr2adjoint2; rename tradjoint2

### DIFF
--- a/spatialmath/base/__init__.py
+++ b/spatialmath/base/__init__.py
@@ -210,6 +210,7 @@ __all__ = [
     "qprint",
     "q2str",
     # spatialmath.base.transforms2d
+    "pos2tr2",
     "rot2",
     "trot2",
     "transl2",
@@ -219,6 +220,9 @@ __all__ = [
     "trexp2",
     "trnorm2",
     "tr2jac2",
+    "tr2pos2",
+    "tr2adjoint2",
+    "tradjoint2",
     "trinterp2",
     "trprint2",
     "trplot2",

--- a/spatialmath/base/transforms2d.py
+++ b/spatialmath/base/transforms2d.py
@@ -16,6 +16,7 @@ tuple, numpy array, numpy row vector or numpy column vector.
 
 import sys
 import math
+import warnings
 import numpy as np
 
 try:
@@ -758,16 +759,16 @@ def trnorm2(T: SE2Array) -> SE2Array:
 
 
 @overload  # pragma: no cover
-def tradjoint2(T: SO2Array) -> R1x1:
+def tr2adjoint2(T: SO2Array) -> R1x1:
     ...
 
 
 @overload  # pragma: no cover
-def tradjoint2(T: SE2Array) -> R3x3:
+def tr2adjoint2(T: SE2Array) -> R3x3:
     ...
 
 
-def tradjoint2(T):
+def tr2adjoint2(T):
     r"""
     Adjoint matrix in 2D
 
@@ -816,6 +817,22 @@ def tradjoint2(T):
         # fmt: on
     else:
         raise ValueError("bad argument")
+
+
+def tradjoint2(T):
+    """
+    Adjoint matrix in 2D (deprecated)
+
+    .. deprecated:: 1.1.16
+        Renamed to :func:`tr2adjoint2` for naming consistency.  This alias
+        will be removed in a future release.
+    """
+    warnings.warn(
+        "tradjoint2 is deprecated since 1.1.16, use tr2adjoint2 instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return tr2adjoint2(T)
 
 
 def tr2jac2(T: SE2Array) -> R3x3:

--- a/tests/base/test_transforms2d.py
+++ b/tests/base/test_transforms2d.py
@@ -144,10 +144,17 @@ class Test2D(unittest.TestCase):
         T = rt2tr(rot2(0.2), [1, 2])
         nt.assert_array_almost_equal(trinv2(T) @ T, np.eye(3))
 
-    def test_tradjoint2(self):
+    def test_tr2adjoint2(self):
         T = xyt2tr([1, 2, 0.2])
         X = [1, 2, 3]
-        nt.assert_almost_equal(tradjoint2(T) @ X, vexa(T @ skewa(X) @ trinv2(T)))
+        nt.assert_almost_equal(tr2adjoint2(T) @ X, vexa(T @ skewa(X) @ trinv2(T)))
+
+    def test_tradjoint2_deprecated(self):
+        T = xyt2tr([1, 2, 0.2])
+        X = [1, 2, 3]
+        with self.assertWarns(DeprecationWarning):
+            result = tradjoint2(T)
+        nt.assert_almost_equal(result @ X, vexa(T @ skewa(X) @ trinv2(T)))
 
     def test_points2tr2(self):
         p1 = np.random.uniform(size=(2, 5))


### PR DESCRIPTION
- Rename tradjoint2 to tr2adjoint2 for naming consistency with 3D (tr2adjoint)
- Add deprecated tradjoint2 alias for backward compatibility (version 1.1.16)
- Export previously internal functions: pos2tr2, tr2pos2, tr2adjoint2
- Update tests to use new name; add deprecation warning test

All 19 transforms2d tests pass. Backward compatibility maintained via DeprecationWarning with version info.