### PR TITLE
fix: support scalar/2-elem dim shorthand in tranimate/Animate

### DIFF
--- a/spatialmath/base/animate.py
+++ b/spatialmath/base/animate.py
@@ -60,10 +60,11 @@ class Animate:
 
         :param ax: the axes to plot into, defaults to current axes
         :type ax: Axes3D reference
-        :param dim: dimension of plot volume as [xmin, xmax, ymin, ymax,
-            zmin, zmax]. If dims is [min, max] those limits are applied
-            to the x-, y- and z-axes.
-        :type dim: array_like(6) or array_like(2)
+        :param dim: dimension of plot volume, using the same shorthand as
+            ``plotvol3``: a scalar ``A`` gives ``[-A,A]`` on every axis, a
+            2-vector ``[A,B]`` gives ``[A,B]`` on every axis, and a 6-vector
+            gives ``[xmin, xmax, ymin, ymax, zmin, zmax]`` explicitly.
+        :type dim: scalar, array_like(2) or array_like(6)
         :param projection: 3D projection: ortho [default] or persp
         :type projection: str
         :param labels: labels for the axes, defaults to X, Y and Z
@@ -105,13 +106,9 @@ class Animate:
             #     # ax.set_aspect('equal')
             ax = smb.plotvol3(ax=ax, dim=dim)
         if dim is not None:
-            dim = list(np.ndarray.flatten(np.array(dim)))
-            if len(dim) == 2:
-                dim = dim * 3
-            elif len(dim) != 6:
-                raise ValueError(
-                    f"dim must have 2 or 6 elements, got {dim}. See docstring for details."
-                )
+            # same shorthand as plotvol3: scalar A -> [-A,A]*3, [A,B] -> [A,B]*3,
+            # or a full [xmin,xmax,ymin,ymax,zmin,zmax]
+            dim = smb.expand_dims(dim, nd=3)
             ax.set_xlim(dim[0:2])
             ax.set_ylim(dim[2:4])
             ax.set_zlim(dim[4:])

--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -3402,8 +3402,8 @@ if _matplotlib_exists:
 
         Examples:
 
-                >>> tranimate(transl(1,2,3)@trotx(1), frame='A', arrow=False, dims=[0, 5])
-                >>> tranimate(transl(1,2,3)@trotx(1), frame='A', arrow=False, dims=[0, 5], movie='spin.mp4')
+                >>> tranimate(transl(1,2,3)@trotx(1), frame='A', arrow=False, dim=[0, 5])
+                >>> tranimate(transl(1,2,3)@trotx(1), frame='A', arrow=False, dim=[0, 5], movie='spin.mp4')
 
         .. note:: For Jupyter this works with the ``notebook`` and ``TkAgg``
             backends.
@@ -3419,7 +3419,9 @@ if _matplotlib_exists:
 
         :seealso: `trplot`, `plotvol3`
         """
-        dim = kwargs.pop("dims", None)
+        # accept dim (matches Animate/plotvol2/plotvol3), keep dims as an
+        # alias for backward compatibility with the previous docstring/API
+        dim = kwargs.pop("dim", kwargs.pop("dims", None))
         ax = kwargs.pop("ax", None)
         anim = Animate(dim=dim, ax=ax, **kwargs)
         anim.trplot(T, **kwargs)


### PR DESCRIPTION
## Summary

`tranimate(T, dim=1.5)` — using the scalar-shorthand `dim` convention
established by `plotvol2`/`plotvol3` elsewhere in this codebase — currently
crashes with:

```
TypeError: spatialmath.base.animate.Animate() got multiple values for keyword argument 'dim'
```

Two compounding bugs, both fixed here:

1. `tranimate()` popped `"dims"` (plural) out of `kwargs` before forwarding
   to `Animate(dim=..., **kwargs)`, but every other function in this
   codebase (`plotvol2`, `plotvol3`, `Animate.__init__` itself) names the
   parameter `dim` (singular). A caller correctly using `dim=` per that
   convention never got popped, so it stayed in `**kwargs` and collided
   with the explicit `dim=dim` already being passed — hence "multiple
   values for keyword argument 'dim'".
2. Even with the right keyword, `Animate.__init__` had its own hand-rolled
   length check that only accepted a 2- or 6-element `dim`, silently
   dropping the scalar-shorthand convention (`A` → `[-A, A]` on every
   axis) that `plotvol3` already supports via the shared `expand_dims()`
   helper — `Animate` just never called it.

## Fix

- `tranimate()` now accepts `dim`, with `dims` kept as a back-compat alias
  for existing callers following the old docstring examples.
- `Animate.__init__` now calls `expand_dims(dim, nd=3)` (the same helper
  `plotvol3` uses) instead of its own incomplete validation, so scalar and
  2-element shorthand work consistently everywhere.

## Regression context

This isn't a long-standing issue — it's a regression from #131 (`Jien Cao`,
2024-07-29, fixing #126), which *introduced* both the `dims` rename and the
new strict length check while trying to "expose `ax` and `dims` arguments
to animate(...), to be consistent with other APIs." Before that commit,
`tranimate` passed `**kwargs` straight through to `Animate`, and scalar
`dim` worked correctly via `Animate`'s existing `plotvol3` delegation.

## Test plan

- [x] Verified directly: `Animate(dim=1.5)`, `Animate(dim=[0,5])`,
      `tranimate(R, dim=1.5, movie=True)`, and `tranimate(R, dims=[0,5],
      movie=True)` (back-compat alias) all construct/run correctly
- [x] Full existing test suite: 342 passed, no regressions