### PR TITLE
Fix sphinx workflow to clone gh-pages from rai-opensource, not petercorke

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -29,7 +29,7 @@ jobs:
         cd ../
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/rai-opensource/spatialmath-python.git --branch gh-pages --single-branch gh-pages
+        git clone https://github.com/${{ github.repository }}.git --branch gh-pages --single-branch gh-pages
         cp -r docs/build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -29,7 +29,7 @@ jobs:
         cd ../
     - name: Commit documentation changes
       run: |
-        git clone https://github.com/petercorke/spatialmath-python.git --branch gh-pages --single-branch gh-pages
+        git clone https://github.com/rai-opensource/spatialmath-python.git --branch gh-pages --single-branch gh-pages
         cp -r docs/build/html/* gh-pages/
         cd gh-pages
         git config --local user.email "action@github.com"


### PR DESCRIPTION
## Summary
- The `Commit documentation changes` step in `.github/workflows/sphinx.yml` still cloned `gh-pages` from the pre-migration `petercorke/spatialmath-python` repo, which has no `gh-pages` branch since the repo moved to `rai-opensource`.
- Every docs build has been failing at that step with `fatal: Remote branch gh-pages not found in upstream origin` (e.g. run [31737932420](https://github.com/rai-opensource/spatialmath-python/actions/runs/31737932420)).
- Points the clone at `rai-opensource/spatialmath-python.git`, which has a `gh-pages` branch already.

## Test plan
- [x] Confirmed `gh-pages` branch exists on `rai-opensource/spatialmath-python`
- [ ] Merge and confirm the `sphinx` workflow succeeds on `master`