### PR TITLE
fix: __version__ guard catches everything and leaves it unset on failure

### DIFF
--- a/spatialmath/__init__.py
+++ b/spatialmath/__init__.py
@@ -51,5 +51,8 @@ try:
     import importlib.metadata
 
     __version__ = importlib.metadata.version("spatialmath-python")
-except:
-    pass
+except importlib.metadata.PackageNotFoundError:
+    # running from a source checkout without an installed/editable
+    # spatialmath-python distribution -- e.g. importing straight from
+    # the repo root
+    __version__ = "unknown"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,22 @@
+import re
+import unittest
+from pathlib import Path
+
+import spatialmath
+
+
+class TestVersion(unittest.TestCase):
+    def test_version_is_a_non_empty_string(self):
+        self.assertIsInstance(spatialmath.__version__, str)
+        self.assertTrue(spatialmath.__version__)
+
+    def test_version_matches_pyproject(self):
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE)
+        self.assertIsNotNone(match, f"couldn't find a version in {pyproject}")
+        self.assertEqual(spatialmath.__version__, match.group(1))
+
+
+# ---------------------------------------------------------------------------------------#
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`spatialmath/__init__.py`'s `__version__` lookup used a bare `except: pass`, which has two problems:

- Catches every exception during the `importlib.metadata.version()` call, not just the "package isn't installed" case (`PackageNotFoundError`) -- masking anything else that might go wrong there.
- On failure, `__version__` never gets set at all -- `spatialmath.__version__` raises `AttributeError` rather than giving something to print, in e.g. a source checkout without an installed/editable distribution.

Narrowed the `except` to `PackageNotFoundError` and added an explicit `"unknown"` fallback so the attribute always exists.

## Test plan

- [x] Normal path: `import spatialmath; spatialmath.__version__` still resolves to the installed version (`1.1.16` locally)
- [x] Failure path: monkeypatched `importlib.metadata.version` to raise `PackageNotFoundError` and confirmed `__version__` falls back to `"unknown"` instead of being unset
- [x] New `tests/test_version.py`: asserts it's a non-empty string and matches `pyproject.toml`'s `version`
