### PR TITLE
Fix SpatialForce/SpatialMomentum SE(3) transform to use the coadjoint (Ad^-T)

### DIFF
--- a/spatialmath/spatialvector.py
+++ b/spatialmath/spatialvector.py
@@ -54,8 +54,8 @@ class SpatialVector(BasePoseList):
     ===================   ====================  ===================  =========================
     SE3, Twist3           SpatialVelocity       SpatialVelocity      adjoint product
     SE3, Twist3           SpatialAcceleration   SpatialAcceleration  adjoint product
-    SE3, Twist3           SpatialMomentum       SpatialMomentum      adjoint transpose product
-    SE3, Twist3           SpatialForce          SpatialForce         adjoint transpose product
+    SE3, Twist3           SpatialMomentum       SpatialMomentum      coadjoint product
+    SE3, Twist3           SpatialForce          SpatialForce         coadjoint product
     SpatialAcceleration   SpatialInertia        SpatialForce         matrix-vector product**
     SpatialVelocity       SpatialInertia        SpatialMomentum      matrix-vector product**
     ===================   ====================  ===================  =========================
@@ -268,8 +268,9 @@ class SpatialVector(BasePoseList):
 
         ``X * S`` transforms the spatial vector ``S`` by the relative pose ``X``
         which may be either an ``SE3`` or ``Twist3`` instance.  The spatial
-        vector is premultiplied by the adjoint of ``X`` or adjoint transpose
-        of ``X`` depending on the SpatialVector subclass of ``S``.
+        vector is premultiplied by the adjoint of ``X``, or by the coadjoint
+        (the inverse-transpose of the adjoint) of ``X``, depending on the
+        SpatialVector subclass of ``S``.
 
         ===========  ====================  ===================  =========================
                    Multiplicands                   Product
@@ -278,19 +279,20 @@ class SpatialVector(BasePoseList):
         ===========  ====================  ===================  =========================
         SE3, Twist3  SpatialVelocity       SpatialVelocity      adjoint product
         SE3, Twist3  SpatialAcceleration   SpatialAcceleration  adjoint product
-        SE3, Twist3  SpatialMomentum       SpatialMomentum      adjoint transpose product
-        SE3, Twist3  SpatialForce          SpatialForce         adjoint transpose product
+        SE3, Twist3  SpatialMomentum       SpatialMomentum      coadjoint product
+        SE3, Twist3  SpatialForce          SpatialForce         coadjoint product
         ===========  ====================  ===================  =========================
         """
         if isinstance(left, (SE3, Twist3)):
-            X = left.Ad()
             if isinstance(right, SpatialM6):
-                return right.__class__(X @ right.A)
+                return right.__class__(left.Ad() @ right.A)
             else:
                 # Force/momentum are dual to motion and transform by the
                 # coadjoint (inverse-transpose of the adjoint), not the
                 # adjoint transpose. These are only equal for a pure rotation.
-                return right.__class__(np.linalg.inv(X).T @ right.A)
+                # Ad(X)^-1 == Ad(X^-1), so take the adjoint of the inverse pose
+                # rather than inverting the 6x6 adjoint.
+                return right.__class__(left.inv().Ad().T @ right.A)
         else:
             raise TypeError("left operand of * must be SE3 or Twist3")
 
@@ -492,7 +494,9 @@ class SpatialForce(SpatialF6):
         # Twist * SpatialForce -> SpatialForce
         # A force is dual to motion, so it transforms by the coadjoint
         # (inverse-transpose of the adjoint), not the adjoint transpose.
-        return SpatialForce(np.linalg.inv(left.Ad()).T @ right.A)
+        # Ad(X)^-1 == Ad(X^-1), so take the adjoint of the inverse pose
+        # rather than inverting the 6x6 adjoint.
+        return SpatialForce(left.inv().Ad().T @ right.A)
 
 
 # ------------------------------------------------------------------------- #

--- a/spatialmath/spatialvector.py
+++ b/spatialmath/spatialvector.py
@@ -287,7 +287,10 @@ class SpatialVector(BasePoseList):
             if isinstance(right, SpatialM6):
                 return right.__class__(X @ right.A)
             else:
-                return right.__class__(X.T @ right.A)
+                # Force/momentum are dual to motion and transform by the
+                # coadjoint (inverse-transpose of the adjoint), not the
+                # adjoint transpose. These are only equal for a pure rotation.
+                return right.__class__(np.linalg.inv(X).T @ right.A)
         else:
             raise TypeError("left operand of * must be SE3 or Twist3")
 
@@ -487,7 +490,9 @@ class SpatialForce(SpatialF6):
         right, left
     ):  # lgtm[py/not-named-self] pylint: disable=no-self-argument
         # Twist * SpatialForce -> SpatialForce
-        return SpatialForce(left.Ad().T @ right.A)
+        # A force is dual to motion, so it transforms by the coadjoint
+        # (inverse-transpose of the adjoint), not the adjoint transpose.
+        return SpatialForce(np.linalg.inv(left.Ad()).T @ right.A)
 
 
 # ------------------------------------------------------------------------- #

--- a/tests/test_spatialvector.py
+++ b/tests/test_spatialvector.py
@@ -228,6 +228,29 @@ class TestSpatialVector(unittest.TestCase):
         # twist x v, twist x a, twist x F
         pass
 
+    def test_spatial_transform_duality(self):
+        # A pose transform acts on motion (velocity/acceleration) by the
+        # adjoint Ad, and on force/momentum by the coadjoint Ad^-T, because
+        # force space is dual to motion space (Featherstone, "Rigid Body
+        # Dynamics Algorithms"). With a nonzero translation the SE(3) adjoint
+        # is not orthogonal, so Ad^-T differs from the adjoint transpose Ad^T.
+        T = SE3(1, 0, 0)
+        # ordering is [v(0:3); omega(3:6)] (see SE3.Ad docstring)
+        v = SpatialVelocity([0, 0, 0, 0, 1, 0])
+        f = SpatialForce([0, 0, 1, 0, 0, 0])
+        v2, f2 = T * v, T * f
+
+        # Instantaneous power f . v is frame-invariant; this is the self-oracle
+        # and is independent of the [v; omega] vs [omega; v] convention.
+        nt.assert_almost_equal(f2.A @ v2.A, f.A @ v.A)
+
+        # Explicit transformed wrench: the moment component flips sign.
+        nt.assert_almost_equal(f2.A, np.r_[0, 0, 1, 0, -1, 0])
+
+        # SpatialMomentum exercises the general SpatialVector.__rmul__ path.
+        m2 = T * SpatialMomentum([0, 0, 1, 0, 0, 0])
+        nt.assert_almost_equal(m2.A, np.r_[0, 0, 1, 0, -1, 0])
+
 
 # ---------------------------------------------------------------------------------------#
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #169.

## Problem

A spatial force/wrench is **dual** to spatial motion, so under an SE(3) transform it must map by the **coadjoint** `Ad^-T` (inverse-transpose of the adjoint), not the adjoint transpose `Ad^T`. Because the SE(3) adjoint is non-orthogonal whenever the translation is nonzero, `Ad^T != Ad^-T`, so `SpatialForce` and `SpatialMomentum` were transformed incorrectly for any pose with translation (correct only for a pure rotation, where `Ad` is orthogonal). Velocity/acceleration (motion), which correctly use `Ad`, were fine.

## Repro / self-oracle

Instantaneous power `f . v` is frame-invariant, so it must be preserved by the transform:

```python
from spatialmath import SE3, SpatialVelocity, SpatialForce
import numpy as np

T = SE3(1, 0, 0)                       # pure +x translation
v = SpatialVelocity([0, 0, 0, 0, 1, 0])
f = SpatialForce([0, 0, 1, 0, 0, 0])

v2, f2 = T * v, T * f
print(f.A @ v.A, f2.A @ v2.A)          # should be equal
# before: 0.0 2.0   <- power not invariant (bug)
# after:  0.0 0.0   <- invariant
```

The transformed wrench's moment component came out with the wrong sign; `f2` should be `[0, 0, 1, 0, -1, 0]` but was `[0, 0, 1, 0, 1, 0]`.

## Fix

Use `np.linalg.inv(Ad).T` (the coadjoint) in `SpatialForce.__rmul__` and in the force/momentum branch of the general `SpatialVector.__rmul__` (which `SpatialMomentum` uses). The motion branch is unchanged.

## Test

The `test_products` stub in `tests/test_spatialvector.py` was empty, so these transforms were untested. Adds `test_spatial_transform_duality` asserting the power invariance (`f2 . v2 == f . v`, convention-independent) plus the explicit transformed wrench and momentum. Red before the fix (power `2 != 0`), green after; the existing motion tests are unaffected.

Reported by @Yuxiang-Ma, who cited Featherstone's *Rigid Body Dynamics Algorithms*.

---
This change was prepared with AI assistance and reviewed by me before submission.
