### PR TITLE
fix: Twist3 * SpatialVector raised ValueError instead of dispatching

### DIFF
--- a/spatialmath/twist.py
+++ b/spatialmath/twist.py
@@ -1106,6 +1106,7 @@ class Twist3(BaseTwist):
         Twist3    scalar                Twist3               element-wise product
         scalar    Twist3                Twist3               element-wise product
         Twist3    SE3                   Twist3               exponential x SE3
+        Twist3    SpatialVector         SpatialVector         adjoint/coadjoint product
         ========  ====================  ===================  ========================
 
         .. note::
@@ -1113,7 +1114,10 @@ class Twist3(BaseTwist):
             #. scalar x Twist is handled by ``__rmul__``
             #. scalar multiplication is commutative but the result is not a group
             operation so the result will be a matrix
-            #. Any other input combinations result in a ValueError.
+            #. ``Twist3 * SpatialVector`` (velocity, acceleration, force, momentum)
+               is handled by falling back to
+               :meth:`~spatialmath.spatialvector.SpatialVector.__rmul__`.
+            #. Any other input combination raises a ``TypeError``.
 
         For pose composition the ``left`` and ``right`` operands may be a sequence
 
@@ -1146,7 +1150,11 @@ class Twist3(BaseTwist):
             # return Twist(left.S * right)
             return Twist3(left.binop(right, lambda x, y: x * y))
         else:
-            raise ValueError("twist *, incorrect right operand")
+            # not a type we handle directly -- return NotImplemented so Python
+            # falls back to right.__rmul__(left), which SpatialVector (velocity,
+            # acceleration, force, momentum) defines. If right has no __rmul__
+            # either, Python raises its own TypeError.
+            return NotImplemented
 
     def __rmul__(
         right, left

--- a/tests/test_spatialvector.py
+++ b/tests/test_spatialvector.py
@@ -225,8 +225,23 @@ class TestSpatialVector(unittest.TestCase):
         # v x v = a  *, v x F6 = a
         # a x I, I x a
         # v x I, I x v
-        # twist x v, twist x a, twist x F
-        pass
+
+        # twist x v, twist x a, twist x F, twist x momentum
+        T = SE3(1, 2, 3) * SE3.Rx(0.3)
+        S = Twist3(T)
+
+        v = SpatialVelocity([1, 2, 3, 4, 5, 6])
+        a = SpatialAcceleration([1, 2, 3, 4, 5, 6])
+        f = SpatialForce([1, 2, 3, 4, 5, 6])
+        m = SpatialMomentum([1, 2, 3, 4, 5, 6])
+
+        # Twist3 * X must agree with the equivalent SE3 * X: same
+        # underlying transform, two ways of expressing it.
+        for x in (v, a, f, m):
+            result = S * x
+            expected = T * x
+            self.assertIsInstance(result, type(x))
+            nt.assert_almost_equal(result.A, expected.A)
 
 
 # ---------------------------------------------------------------------------------------#


### PR DESCRIPTION
## Summary
- `Twist3.__mul__` raised a hard `ValueError` for any right operand it didn't directly recognize (`Twist3`, `SE3`, scalar), instead of returning `NotImplemented`. That meant Python never fell back to `right.__rmul__(left)`, so `Twist3 * SpatialVelocity` / `SpatialAcceleration` / `SpatialForce` / `SpatialMomentum` all failed unconditionally -- even though `SpatialVector.__rmul__` explicitly documents supporting `Twist3` alongside `SE3` (`isinstance(left, (SE3, Twist3))`).
- Found while independently verifying #207 (`SpatialForce`/`SpatialMomentum` coadjoint fix): that PR's `Twist3` code path (`SpatialForce.__rmul__`'s own override) is mathematically correct but was untestable through normal `*` syntax because of this bug -- it only worked via `SE3 *`.
- Fix: return `NotImplemented` for unrecognized right operands instead of raising. Genuinely unsupported types (e.g. `Twist3(...) * "hello"`) still fail, now with Python's standard `TypeError` rather than a custom `ValueError`.
- Updates `Twist3.__mul__`'s own docstring table, which didn't mention `SpatialVector` as a supported right operand at all.
- Fills in the `tests/test_spatialvector.py::test_products` stub (previously just `pass`, with a comment literally noting "twist x v, twist x a, twist x F" as untested) -- checks `Twist3 * X` agrees with the equivalent `SE3 * X` for all four `SpatialVector` subclasses.

## Test plan
- [x] New test fails on unfixed code: `ValueError: twist *, incorrect right operand`
- [x] Passes after the fix, for all of `SpatialVelocity`/`SpatialAcceleration`/`SpatialForce`/`SpatialMomentum`
- [x] Confirmed genuinely unsupported types still fail, now with `TypeError` (Python's standard) instead of the old custom `ValueError`
- [x] Grepped `tests/` for anything asserting the old `ValueError` -- nothing depends on it
- [x] `pytest tests/` -- full suite, 342 passed, no regressions