### PR TITLE
perf(base): speed up isR/ishom/ishom2 orthogonality checks

### DIFF
--- a/spatialmath/base/transforms2d.py
+++ b/spatialmath/base/transforms2d.py
@@ -361,7 +361,12 @@ def ishom2(T: Any, check: bool = False, tol: float = 20) -> bool:  # TypeGuard(S
         and T.shape == (3, 3)
         and (
             not check
-            or (smb.isR(T[:2, :2], tol=tol) and all(T[2, :] == np.array([0, 0, 1])))
+            or (
+                smb.isR(T[:2, :2], tol=tol)
+                and T[2, 0] == 0
+                and T[2, 1] == 0
+                and T[2, 2] == 1
+            )
         )
     )
 

--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -382,7 +382,13 @@ def ishom(T: Any, check: bool = False, tol: float = 20) -> bool:
         and T.shape == (4, 4)
         and (
             not check
-            or (isR(T[:3, :3], tol=tol) and all(T[3, :] == np.array([0, 0, 0, 1])))
+            or (
+                isR(T[:3, :3], tol=tol)
+                and T[3, 0] == 0
+                and T[3, 1] == 0
+                and T[3, 2] == 0
+                and T[3, 3] == 1
+            )
         )
     )
 

--- a/spatialmath/base/transformsNd.py
+++ b/spatialmath/base/transformsNd.py
@@ -378,10 +378,34 @@ def isR(R: NDArray, tol: float = 20) -> bool:  # -> TypeGuard[SOnArray]:
 
     :seealso: isrot2, isrot
     """
-    return bool(
-        np.linalg.norm(R @ R.T - np.eye(R.shape[0])) < tol * _eps
-        and np.linalg.det(R) > 0
-    )
+    n = R.shape[0]
+    if n == 3:
+        # explicit cofactor expansion avoids the dispatch overhead of
+        # np.linalg.det/norm, which dominates cost for such a small matrix
+        det = (
+            R[0, 0] * (R[1, 1] * R[2, 2] - R[1, 2] * R[2, 1])
+            - R[0, 1] * (R[1, 0] * R[2, 2] - R[1, 2] * R[2, 0])
+            + R[0, 2] * (R[1, 0] * R[2, 1] - R[1, 1] * R[2, 0])
+        )
+        if det <= 0:
+            return False
+        D = R @ R.T
+        D[0, 0] -= 1.0
+        D[1, 1] -= 1.0
+        D[2, 2] -= 1.0
+        return bool(np.sum(D * D) < (tol * _eps) ** 2)
+    elif n == 2:
+        det = R[0, 0] * R[1, 1] - R[0, 1] * R[1, 0]
+        if det <= 0:
+            return False
+        D = R @ R.T
+        D[0, 0] -= 1.0
+        D[1, 1] -= 1.0
+        return bool(np.sum(D * D) < (tol * _eps) ** 2)
+    else:
+        return bool(
+            np.linalg.norm(R @ R.T - np.eye(n)) < tol * _eps and np.linalg.det(R) > 0
+        )
 
 
 def isskew(S: NDArray, tol: float = 20) -> bool:  # -> TypeGuard[sonArray]:


### PR DESCRIPTION
## Summary
- `isR` (SO(2)/SO(3) orthogonality test used by `SE3`/`SO3`/`SE2`/`SO2` construction with `check=True`) previously went through `np.linalg.det`/`np.linalg.norm`/`np.eye`, whose generic dispatch overhead dominates cost for such small (2x2/3x3) matrices. Added explicit fast paths for the 3x3 and 2x2 cases using a hand-written cofactor-expansion determinant and a squared-residual orthogonality check, falling back to the original generic implementation for any other size.
- `ishom`/`ishom2` bottom-row validity checks replaced `all(T[-1,:] == np.array([...]))` (array allocation + Python-level `all()` over a NumPy bool array) with direct scalar comparisons.
- Net effect: `isR` is roughly 2x faster standalone, and `SE3(T, check=True)` construction is roughly 30-40% faster end to end.

## Test plan
- [x] `pytest tests/` — 343 passed
- [x] Verified pre-existing behaviour for symbolic (SymPy `dtype=object`) matrices with `check=True` is unchanged (was already unsupported before this change, for unrelated reasons - `np.linalg.det`/`norm` don't support `dtype=object` either)

🤖 Generated with [Claude Code](https://claude.com/claude-code)