### PR TITLE
ci: rename workflow to CI for badge consistency

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,7 +2,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: build
+name: CI
 
 on:
   push:


### PR DESCRIPTION
The workflow was named \`build\`, which is what its GitHub Actions badge displays. Renaming it to \`CI\` aligns the badge label with the other repos in the RVC ecosystem (robotics-toolbox-python, machinevision-toolbox-python, bdsim, pgraph-python, sphinx-pyrunblock, ansitable), all of which already show a consistent "CI" badge rather than a repo-specific workflow name.

No functional change to the workflow itself.